### PR TITLE
PS4 port: handle missing signal.h, include YiPort.h, and replace localtime_r

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,13 @@ if (TVOS)
   set(HAVE_SYSCALL_H OFF CACHE INTERNAL OFF FORCE)
 endif()
 
+if (PS4)
+  message ("YOUI -> on PS4 we can't do unwind, sigaction or fcntl")
+  set(HAVE_UNWIND_H OFF CACHE INTERNAL OFF FORCE)
+  set(HAVE_SIGACTION OFF CACHE INTERNAL OFF FORCE)
+  set(HAVE_FCNTL OFF CACHE INTERNAL OFF FORCE)
+endif()
+
 # NOTE gcc does not fail if you pass a non-existent -Wno-* option as an
 # argument. However, it will happily fail if you pass the corresponding -W*
 # option. So, we check whether options that disable warnings exist by testing

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -29,6 +29,10 @@
 
 #define _GNU_SOURCE 1 // needed for O_NOFOLLOW and pread()/pwrite()
 
+#if defined(YI_PORT_FILE_REQUIRED)
+#include <YiPort.h>
+#endif
+
 #include "utilities.h"
 
 #include <algorithm>
@@ -65,6 +69,16 @@
 
 #ifdef HAVE_STACKTRACE
 # include "stacktrace.h"
+#endif
+
+#if defined(__ORBIS__)
+#include <time.h>
+// localtime_r replacement, like from windows port.h
+struct tm* localtime_r(const time_t* timep, struct tm* result) {
+  struct tm* r = localtime(timep);
+  *result = *r;
+  return result;
+}
 #endif
 
 using std::string;
@@ -935,7 +949,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
     linkpath += linkname;
     unlink(linkpath.c_str());                    // delete old one if it exists
 
-#if defined(OS_WINDOWS)
+#if defined(OS_WINDOWS) || defined (__ORBIS__)
     // TODO(hamaji): Create lnk file on Windows?
 #elif defined(HAVE_UNISTD_H)
     // We must have unistd.h.

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -31,12 +31,21 @@
 //
 // Implementation of InstallFailureSignalHandler().
 
+#if defined(YI_PORT_FILE_REQUIRED)
+#include <YiPort.h>
+#endif
+
 #include "utilities.h"
 #include "stacktrace.h"
 #include "symbolize.h"
 #include "glog/logging.h"
 
+#if defined(__ORBIS__)
+// Skip signal on PS4
+#else
 #include <signal.h>
+#endif
+
 #include <time.h>
 #ifdef HAVE_UCONTEXT_H
 # include <ucontext.h>

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -29,12 +29,21 @@
 //
 // Author: Shinichiro Hamaji
 
+#if defined(YI_PORT_FILE_REQUIRED)
+#include <YiPort.h>
+#endif
+
 #include "utilities.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
+#if defined(__ORBIS__)
+// Skip signal on PS4
+#else
 #include <signal.h>
+#endif
+
 #ifdef HAVE_SYS_TIME_H
 # include <sys/time.h>
 #endif

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -32,6 +32,10 @@
 // Broken out from logging.cc by Soren Lassen
 // logging_unittest.cc covers the functionality herein
 
+#if defined(YI_PORT_FILE_REQUIRED)
+#include <YiPort.h>
+#endif
+
 #include "utilities.h"
 
 #include <string.h>


### PR DESCRIPTION
…

The YiPort.h file includes numerous missing methods and functions. The signal.h
file is missing in the SDK so must wrap in conditionals, and don't use some other
missing features. Note that the localtime_r() replacement function is not
implemented so won't work as expected.